### PR TITLE
fix: issues in splitting URL based on ":"

### DIFF
--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -217,7 +217,6 @@ class DefaultStrategy(AbstractStrategy):
                 port = os.getenv("DOCUMENTATION_PORT")
                 path = port_and_page[len(port):]
                 record['url'] = f"{http}s://{cname}{path}"
-    
             records.append(record)
 
         return records

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -212,15 +212,16 @@ class DefaultStrategy(AbstractStrategy):
             # Example:
             # http://localhost:1314/index.html#pyansys-actions
             cname = os.getenv("DOCUMENTATION_CNAME")
-            if cname is not None:
-                print(record["url"])
-                print(record["url"].split(":"))
-                http, _, port_and_page = record["url"].split(":")
-                port = os.getenv("DOCUMENTATION_PORT")
-                path = port_and_page[len(port):]
-                record['url'] = f"{http}s://{cname}{path}"
-
-            records.append(record)
+            try:
+                if cname is not None:
+                    http, _, port_and_page = record["url"].split(":")
+                    port = os.getenv("DOCUMENTATION_PORT")
+                    path = port_and_page[len(port):]
+                    record['url'] = f"{http}s://{cname}{path}"
+    
+                records.append(record)
+            except Exception as err:
+                raise Exception(f"URL: {record["url"]}")
 
         return records
 

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -214,7 +214,7 @@ class DefaultStrategy(AbstractStrategy):
             cname = os.getenv("DOCUMENTATION_CNAME")
             try:
                 if cname is not None:
-                    http, _, port_and_page = record["url"].split(":")
+                    http, _, port_and_page = record["url"].split(":", 2)
                     port = os.getenv("DOCUMENTATION_PORT")
                     path = port_and_page[len(port):]
                     record['url'] = f"{http}s://{cname}{path}"

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -213,6 +213,8 @@ class DefaultStrategy(AbstractStrategy):
             # http://localhost:1314/index.html#pyansys-actions
             cname = os.getenv("DOCUMENTATION_CNAME")
             if cname is not None:
+                print(record["url"])
+                print(record["url"].split(":"))
                 http, _, port_and_page = record["url"].split(":")
                 port = os.getenv("DOCUMENTATION_PORT")
                 path = port_and_page[len(port):]

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -212,16 +212,13 @@ class DefaultStrategy(AbstractStrategy):
             # Example:
             # http://localhost:1314/index.html#pyansys-actions
             cname = os.getenv("DOCUMENTATION_CNAME")
-            try:
-                if cname is not None:
-                    http, _, port_and_page = record["url"].split(":", 2)
-                    port = os.getenv("DOCUMENTATION_PORT")
-                    path = port_and_page[len(port):]
-                    record['url'] = f"{http}s://{cname}{path}"
+            if cname is not None:
+                http, _, port_and_page = record["url"].split(":", 2)
+                port = os.getenv("DOCUMENTATION_PORT")
+                path = port_and_page[len(port):]
+                record['url'] = f"{http}s://{cname}{path}"
     
-                records.append(record)
-            except Exception as err:
-                raise Exception(f"URL: {record['url']}")
+            records.append(record)
 
         return records
 

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -221,7 +221,7 @@ class DefaultStrategy(AbstractStrategy):
     
                 records.append(record)
             except Exception as err:
-                raise Exception(f"URL: {record["url"]}")
+                raise Exception(f"URL: {record['url']}")
 
         return records
 

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -217,6 +217,7 @@ class DefaultStrategy(AbstractStrategy):
                 port = os.getenv("DOCUMENTATION_PORT")
                 path = port_and_page[len(port):]
                 record['url'] = f"{http}s://{cname}{path}"
+
             records.append(record)
 
         return records


### PR DESCRIPTION
We should perform a "max split" of 2, not undetermined, in order to make it robust.